### PR TITLE
fix change attributes for non sortable relations

### DIFF
--- a/traits/SortableRelations.php
+++ b/traits/SortableRelations.php
@@ -106,10 +106,9 @@ trait SortableRelations
 
                     $ids = $newIds;
                 }
-
-                return [$ids, $attributes];
             }
         }
+        return [$ids, $attributes];
     }
 
     /**


### PR DESCRIPTION
Using sortable trait in a model with non sortable relations raises an error - function changeAttributes don't enter in the cycle and always return void (null). In backend panel it means execption on attach relation.